### PR TITLE
Set up the class to automatically create the ARIA component

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,31 @@
 'use strict';
 
-/** Simple wrapper class for WebTTS, or additionally to update ARIA DOMNode to automatically read with screen reading technology.
-	* @param {boolean} webTTS - whether to use WebTTS or ARIA
-
-*/
-
+/** Text-to-speech using the Web Speech API or ARIA
+ * (ARIA-based speech will only be heard if using a
+ * screen reader, such as NVDA or VoiceOver)
+ */
 class TTS {
+	
+	/** Simple wrapper class for WebTTS, or additionally to update ARIA DOMNode to automatically read with screen reading technology.
+	 * @param {boolean} webTTS - whether to use WebTTS or ARIA
+	 */
 	constructor(webTTS = false) {
+		
+		// Set up Web Speech API stuff
 		this.synth = window.speechSynthesis;
 		this.webTTS = webTTS;
+
+		// Set up ARIA stuff
+		this.aria = document.createElement('div');
+		this.aria.id = "speech";
+		this.aria.style = "position: absolute; left: 0px; top: -400px";
+		this.aria.setAttribute("aria-live", "assertive");
+		document.body.appendChild(this.aria);
 	}
 
 	/** Speaks a string.
-	* @param {string} text - The text to be spoken.
-*/
+	 * @param {string} text - The text to be spoken.
+	 */
 	speak(text) {
 		if (this.webTTS) {
 			const utterThis = new SpeechSynthesisUtterance(text);
@@ -22,17 +34,17 @@ this.synth.stop();
 			}
 			this.synth.speak(utterThis);
 		} else {
-			document.getElementById('speech').innerHTML = '';
+			this.aria.innerHTML = '';
 			const para = document.createElement('p');
 			para.appendChild(document.createTextNode(text));
-			document.getElementById('speech').appendChild(para);
+			this.aria.appendChild(para);
 		}
 	}
-
 	// End speak()
+	
 	/** Sets webTTS to true or false.
-	* @param {boolean} tts - True to use WebTTS, false to use ARIA
-*/
+	 * @param {boolean} tts - True to use WebTTS, false to use ARIA
+	 */
 	setWebTTS(tts) {
 		this.webTTS = tts;
 	}


### PR DESCRIPTION
First off, let me just say thanks for building these libraries!  I've been slowly working to build something like this for a long time.  There are libraries for video games, AJAX calls to date formatting, to everything but audio games... UNTIL NOW!  Nice work. :)

But anyway, if using ARIA, the TTS class requires end-developers to create an element with id="speech" and the correct settings.  But they might not know the right way to do that, and IMO the whole
point of this kind of abstraction is to hide complexity and speed up dev time.  So I figured the class should probably just do it for us.

I've tested these changes on:
 * Firefox 62.0 (64-bit)
 * Chrome 68.0.3440.106 (Official Build) (64-bit) 
 * NVDA 2018.2 
 * Windows 10,
and it worked great with both Web Speech and ARIA.